### PR TITLE
Add functionality to wait services

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ kubectl plugin wait po/mypod
 **Supported Resource Types**
 * pods
 * deployments
+* services
 
 ## Install the plugin
 ```console

--- a/main.go
+++ b/main.go
@@ -94,6 +94,19 @@ func waitOrDie(resourceType, resourceName string, timeout, interval time.Duratio
 			fmt.Printf("error: %s", err)
 			os.Exit(-1)
 		}
+	case "svc", "service":
+		err := wait.PollImmediate(interval, timeout,
+			func() (bool, error) {
+				s, err := getService(client, ns, resourceName)
+				if err != nil {
+					return false, err
+				}
+				return isServiceReady(s), nil
+			})
+		if err != nil {
+			fmt.Printf("error: %v", err)
+			os.Exit(-1)
+		}
 	default:
 		fmt.Printf("unsupported resource type: %s\n", resourceType)
 		os.Exit(1)

--- a/service.go
+++ b/service.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func getService(client *kubernetes.Clientset, ns, name string) (*corev1.Service, error) {
+	return client.CoreV1().Services(ns).Get(name, metav1.GetOptions{})
+}
+
+func isServiceReady(service *corev1.Service) bool {
+	// if service type is LoadBalancer, wait until an IP is assigned
+	if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
+		if len(service.Status.LoadBalancer.Ingress) == 0 {
+			return false
+		}
+		return true
+	}
+
+	// for ClusterIP, NodePort and ExternalName return true
+	return true
+}


### PR DESCRIPTION
This PR adds the ability to wait for a service.

For `LoadBalancer` type services, it waits until there is an IP address. For the other service types (`ClusterIP`, `NodePort` and `ExternalName`) simply return true, as there is no waiting required.

To test this, create a new `LoadBalancer` type service and execute `kubectl plugin wait svc/<service-name>` - this will wait until the public IP is assigned to the service.
